### PR TITLE
Install git in Docker build to satisfy pip VCS dependencies

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,8 +1,10 @@
 # Use a slim version of Python 3.11 as the base image
 FROM python:3.11-slim
 
-# Install Cairo
-RUN apt-get update && apt-get install -y libcairo2
+# Install Cairo and git for pip VCS dependencies
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libcairo2 git \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set the working directory inside the container to /app
 WORKDIR /app


### PR DESCRIPTION
### Motivation
- The Docker build was failing because `pip install -r requirements.txt` tries to install a VCS package (`git+https://...`) but the `python:3.11-slim` base image did not include `git`.

### Description
- Update `dockerfile` to install `git` alongside `libcairo2` in a single `RUN` layer using `apt-get install -y --no-install-recommends libcairo2 git`.
- Clean up apt lists with `rm -rf /var/lib/apt/lists/*` to reduce image size.
- Preserve existing `WORKDIR`, dependency install, and `CMD` behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980e4cf3344833085f85cb67cee1fa2)